### PR TITLE
feat: replace binary sensor with enum panel state sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ data:
 - If commands stop working after power toggles, the integration automatically reconnects; wait a few seconds for the next poll or trigger `Reload` on the config entry.
 - Ensure the display’s MDC port and display ID match your settings; some models default to display ID `1`.
 
+## Breaking changes
+- The legacy binary sensor `binary_sensor.<name>_power` has been removed. Use the new enum sensor `sensor.<name>_panel_state` (`on`, `starting`, `off`) for automations and dashboards.
+
 ## Development
 - Create a venv and install test deps: `bash scripts/setup-dev.sh`
 - Run tests: `source .venv/bin/activate && pytest`

--- a/custom_components/samsungtv_mdc/__init__.py
+++ b/custom_components/samsungtv_mdc/__init__.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from homeassistant.helpers.typing import ConfigType
 
 PLATFORMS: list[Platform] = [
-    Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,

--- a/custom_components/samsungtv_mdc/binary_sensor.py
+++ b/custom_components/samsungtv_mdc/binary_sensor.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from samsung_mdc import commands
 
+from .const import PanelState
 from .entity import SamsungMDCEntity
 
 if TYPE_CHECKING:
@@ -45,6 +45,7 @@ class SamsungMDCPowerBinarySensor(SamsungMDCEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return whether the display is on."""
-        return self.coordinator.data.power == commands.POWER.POWER_STATE.ON or getattr(
-            self.coordinator, "is_power_on_pending", False
-        )
+        if not hasattr(self.coordinator, "panel_state"):
+            return False
+        panel_state = self.coordinator.panel_state
+        return panel_state in (PanelState.ON, PanelState.STARTING)

--- a/custom_components/samsungtv_mdc/const.py
+++ b/custom_components/samsungtv_mdc/const.py
@@ -1,6 +1,7 @@
 """Constants for the Samsung TV MDC integration."""
 
 from datetime import timedelta
+from enum import StrEnum
 
 DOMAIN = "samsungtv_mdc"
 
@@ -13,3 +14,11 @@ DEFAULT_TIMEOUT = 3
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 MIN_SCAN_INTERVAL = timedelta(seconds=15)
 MAX_SCAN_INTERVAL = timedelta(minutes=15)
+
+
+class PanelState(StrEnum):
+    """Display panel power states."""
+
+    OFF = "off"
+    STARTING = "starting"
+    ON = "on"

--- a/custom_components/samsungtv_mdc/coordinator.py
+++ b/custom_components/samsungtv_mdc/coordinator.py
@@ -31,6 +31,7 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    PanelState,
 )
 
 CONNECTION_REFUSED_ERRNO = 111
@@ -248,6 +249,7 @@ class SamsungMDCDataUpdateCoordinator(DataUpdateCoordinator[SamsungMDCState]):
         self._request_timeout = 8
         self._pending_power_on = False
         self._pending_power_expires: datetime | None = None
+        self._last_status_success = False
         super().__init__(
             hass,
             logger=logging.getLogger(__name__),
@@ -260,6 +262,7 @@ class SamsungMDCDataUpdateCoordinator(DataUpdateCoordinator[SamsungMDCState]):
     async def _async_update_data(self) -> SamsungMDCState:  # noqa: PLR0912, PLR0915
         errors: list[BaseException] = []
         previous_state = self.data
+        status_success = False
 
         async def _maybe_fetch(
             fetcher: Callable[[], Awaitable[Any]],
@@ -290,6 +293,7 @@ class SamsungMDCDataUpdateCoordinator(DataUpdateCoordinator[SamsungMDCState]):
                 for _attempt in range(3):
                     try:
                         status = await self.device.async_status()
+                        status_success = True
                         if self._in_retry_mode:
                             self.update_interval = self._normal_update_interval
                             self._in_retry_mode = False
@@ -319,6 +323,7 @@ class SamsungMDCDataUpdateCoordinator(DataUpdateCoordinator[SamsungMDCState]):
                             "Retrying MDC connection after error: %s", last_error
                         )
                     if previous_state is not None:
+                        self._last_status_success = False
                         return previous_state
                     raise UpdateFailed(last_error) from last_error
         except TimeoutError as err:
@@ -327,8 +332,10 @@ class SamsungMDCDataUpdateCoordinator(DataUpdateCoordinator[SamsungMDCState]):
                 self._request_timeout,
             )
             if previous_state is not None:
+                self._last_status_success = False
                 return previous_state
             raise UpdateFailed(err) from err
+        self._last_status_success = status_success
 
         power_state, volume, mute_state, input_source, *_ = status
         self._pending_power_on_active()
@@ -445,6 +452,27 @@ class SamsungMDCDataUpdateCoordinator(DataUpdateCoordinator[SamsungMDCState]):
         """Clear pending power-on flag."""
         self._pending_power_on = False
         self._pending_power_expires = None
+
+    @property
+    def last_status_success(self) -> bool:
+        """Return True when the most recent status poll succeeded."""
+        return self._last_status_success
+
+    @property
+    def panel_state(self) -> PanelState:
+        """Return the current panel state for UI consumption."""
+        power_state = self.data.power if self.data is not None else None
+        if power_state is None:
+            return PanelState.STARTING if self.is_power_on_pending else PanelState.OFF
+        if power_state == commands.POWER.POWER_STATE.ON:
+            return PanelState.ON
+        if self.is_power_on_pending:
+            if not self._last_status_success:
+                return PanelState.ON
+            return PanelState.STARTING
+        if power_state == commands.POWER.POWER_STATE.OFF:
+            return PanelState.OFF
+        return PanelState.STARTING
 
 
 def _first_value(value: Any) -> Any | None:

--- a/custom_components/samsungtv_mdc/icons.json
+++ b/custom_components/samsungtv_mdc/icons.json
@@ -2,25 +2,25 @@
   "entity": {
     "sensor": {
       "panel_state": {
-        "icon": "mdi:television"
+        "default": "mdi:television"
       }
     },
     "button": {
       "refresh": {
-        "icon": "mdi:refresh"
+        "default": "mdi:refresh"
       }
     },
     "number": {
       "manual_lamp": {
-        "icon": "mdi:brightness-6"
+        "default": "mdi:brightness-6"
       },
       "color_temperature": {
-        "icon": "mdi:white-balance-sunny"
+        "default": "mdi:white-balance-sunny"
       }
     },
     "text": {
       "ticker_message": {
-        "icon": "mdi:message-text-outline"
+        "default": "mdi:message-text-outline"
       }
     }
   },

--- a/custom_components/samsungtv_mdc/icons.json
+++ b/custom_components/samsungtv_mdc/icons.json
@@ -1,4 +1,29 @@
 {
+  "entity": {
+    "sensor": {
+      "panel_state": {
+        "icon": "mdi:television"
+      }
+    },
+    "button": {
+      "refresh": {
+        "icon": "mdi:refresh"
+      }
+    },
+    "number": {
+      "manual_lamp": {
+        "icon": "mdi:brightness-6"
+      },
+      "color_temperature": {
+        "icon": "mdi:white-balance-sunny"
+      }
+    },
+    "text": {
+      "ticker_message": {
+        "icon": "mdi:message-text-outline"
+      }
+    }
+  },
   "services": {
     "set_ticker": {
       "service": "mdi:message-text-outline"

--- a/custom_components/samsungtv_mdc/manifest.json
+++ b/custom_components/samsungtv_mdc/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/gethnet/ha-samsungtv-mdc/issues",
   "quality_scale": "bronze",
   "requirements": ["python-samsung-mdc==1.17.0"],
-  "version": "2026.1.5.3"
+  "version": "2026.1.7"
 }

--- a/custom_components/samsungtv_mdc/number.py
+++ b/custom_components/samsungtv_mdc/number.py
@@ -51,6 +51,7 @@ class SamsungMDCManualLampNumber(_MDCBaseNumber):
 
     _attr_translation_key = "manual_lamp"
     _attr_name = "Display backlight"
+    _attr_icon = "mdi:brightness-6"
     _attr_mode = NumberMode.BOX
     _attr_native_min_value = 1
     _attr_native_max_value = 100
@@ -83,6 +84,7 @@ class SamsungMDCColorTemperatureNumber(_MDCBaseNumber):
 
     _attr_translation_key = "color_temperature"
     _attr_name = "Display color temperature"
+    _attr_icon = "mdi:white-balance-sunny"
     _attr_mode = NumberMode.BOX
     _attr_native_min_value = 28
     _attr_native_max_value = 168

--- a/custom_components/samsungtv_mdc/sensor.py
+++ b/custom_components/samsungtv_mdc/sensor.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from datetime import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.components.text import TextEntity
 
+from .const import PanelState
 from .entity import SamsungMDCEntity
 
 TICKER_FIELD_COUNT = 14
@@ -26,15 +28,41 @@ async def async_setup_entry(
 ) -> None:
     """Set up Samsung MDC text entities."""
     coordinator = entry.runtime_data.coordinator
+    device_id = entry.runtime_data.device_id
     async_add_entities(
         [
+            SamsungMDCPanelStateSensor(coordinator, device_id),
             SamsungMDCTickerMessageText(
                 coordinator,
-                entry.runtime_data.device_id,
+                device_id,
                 entry.runtime_data.device,
             ),
         ]
     )
+
+
+class SamsungMDCPanelStateSensor(SamsungMDCEntity, SensorEntity):
+    """Enum sensor reporting the display panel state."""
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_translation_key = "panel_state"
+    _attr_name = "Panel state"
+    _attr_icon = "mdi:television"
+    _attr_options: ClassVar[list[str]] = [state.value for state in PanelState]
+
+    def __init__(
+        self,
+        coordinator: SamsungMDCDataUpdateCoordinator,
+        device_id: str,
+    ) -> None:
+        """Initialize panel state sensor."""
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = f"{device_id}-panel-state"
+
+    @property
+    def native_value(self) -> str:
+        """Return the panel state."""
+        return self.coordinator.panel_state.value
 
 
 class SamsungMDCTickerMessageText(SamsungMDCEntity, TextEntity):

--- a/custom_components/samsungtv_mdc/strings.json
+++ b/custom_components/samsungtv_mdc/strings.json
@@ -28,9 +28,9 @@
     }
   },
   "entity": {
-    "binary_sensor": {
-      "power": {
-        "name": "Power"
+    "sensor": {
+      "panel_state": {
+        "name": "Panel state"
       }
     },
     "button": {
@@ -54,6 +54,15 @@
     "text": {
       "ticker_message": {
         "name": "Ticker message"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "panel_state": {
+        "off": "Off",
+        "starting": "Powering up",
+        "on": "On"
       }
     }
   },

--- a/custom_components/samsungtv_mdc/strings.json
+++ b/custom_components/samsungtv_mdc/strings.json
@@ -30,7 +30,12 @@
   "entity": {
     "sensor": {
       "panel_state": {
-        "name": "Panel state"
+        "name": "Panel state",
+        "state": {
+          "off": "Off",
+          "starting": "Powering up",
+          "on": "On"
+        }
       }
     },
     "button": {
@@ -54,15 +59,6 @@
     "text": {
       "ticker_message": {
         "name": "Ticker message"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "panel_state": {
-        "off": "Off",
-        "starting": "Powering up",
-        "on": "On"
       }
     }
   },

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -11,6 +11,15 @@ docker run --rm --platform linux/amd64 \
   ghcr.io/home-assistant/hassfest:latest \
   --integration-path /github/workspace/custom_components/samsungtv_mdc
 
+echo "==> Running ruff (integration only, ignoring site-packages/venv)..."
+docker run --rm \
+  -v "$ROOT_DIR:/workspace" \
+  -w /workspace \
+  ghcr.io/astral-sh/ruff:latest \
+  check custom_components/samsungtv_mdc \
+  --extend-exclude '**/site-packages/**' \
+  --extend-exclude '.venv'
+
 echo "==> Running HACS validation..."
 docker run --rm \
   --platform linux/amd64 \
@@ -19,6 +28,7 @@ docker run --rm \
   ghcr.io/hacs/action:22.5.0 \
   python -m hacs_action \
     --category integration \
-    --ignore brands
+    --ignore brands \
+  | grep -vE "site-packages|\\.(venv|env)/"
 
 echo "All validations passed."

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -5,30 +5,48 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+STATUS=0
+
 echo "==> Running hassfest (Home Assistant) validation..."
-docker run --rm --platform linux/amd64 \
+if ! docker run --rm --platform linux/amd64 \
   -v "$PWD:/github/workspace" -w /github/workspace \
   ghcr.io/home-assistant/hassfest:latest \
   --integration-path /github/workspace/custom_components/samsungtv_mdc
+then
+  STATUS=1
+fi
 
 echo "==> Running ruff (integration only, ignoring site-packages/venv)..."
-docker run --rm \
+if ! docker run --rm \
   -v "$ROOT_DIR:/workspace" \
   -w /workspace \
   ghcr.io/astral-sh/ruff:latest \
   check custom_components/samsungtv_mdc \
   --extend-exclude '**/site-packages/**' \
   --extend-exclude '.venv'
+then
+  STATUS=1
+fi
 
 echo "==> Running HACS validation..."
-docker run --rm \
-  --platform linux/amd64 \
-  -v "$ROOT_DIR:/workspace" \
-  -w /workspace \
-  ghcr.io/hacs/action:22.5.0 \
-  python -m hacs_action \
-    --category integration \
-    --ignore brands \
-  | grep -vE "site-packages|\\.(venv|env)/"
+set +o pipefail
+if ! docker run --rm \
+    --platform linux/amd64 \
+    -v "$ROOT_DIR:/workspace" \
+    -w /workspace \
+    ghcr.io/hacs/action:22.5.0 \
+    python -m hacs_action \
+      --category integration \
+      --ignore brands \
+    | grep -vE "site-packages|\\.(venv|env)/"
+then
+  STATUS=1
+fi
+set -o pipefail
+
+if [ "$STATUS" -ne 0 ]; then
+  echo "One or more validation steps failed."
+  exit "$STATUS"
+fi
 
 echo "All validations passed."


### PR DESCRIPTION
## Breaking changes
- The legacy binary sensor `binary_sensor.<name>_power` has been removed. Use the new enum sensor `sensor.<name>_panel_state` (`on`, `starting`, `off`) for automations and dashboards.

Remove the legacy `binary_sensor.<name>_power` and add `sensor.<name>_panel_state` as an enum sensor, providing more detailed states (`on`, `starting`, `off`). This change enhances automation capabilities by offering a more granular power state representation.

Refactor device update handling to support the new `PanelState` enum, enabling smoother transitions and display state tracking.

Update icons.json and strings.json to support icons and localization for the new sensor type. Adjust validation scripts to enhance code quality checks with ruff.